### PR TITLE
Specify digest for distroless image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN CGO_ENABLED=0 \
     GOARCH=$TARGETARCH \
     go build
 
-FROM gcr.io/distroless/static
+FROM gcr.io/distroless/static:latest@sha256:c3c3d0230d487c0ad3a0d87ad03ee02ea2ff0b3dcce91ca06a1019e07de05f12
 
 COPY --from=builder /app/oidc-rp /
 


### PR DESCRIPTION
This ensures that builds are reproducible and always use the same `distroless` image.